### PR TITLE
Base project complete for testing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/src/main/java/com/example/batterysimulator_db_operations/Simulation.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/Simulation.java
@@ -1,0 +1,26 @@
+package com.example.batterysimulator_db_operations;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Simulation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long simId;
+
+    @Enumerated(EnumType.STRING)
+    private SimulationType simulationType;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "simulation_simId")
+    private List<SimulationResults> simulationResults;
+}

--- a/src/main/java/com/example/batterysimulator_db_operations/SimulationController.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/SimulationController.java
@@ -1,0 +1,38 @@
+package com.example.batterysimulator_db_operations;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+public class SimulationController {
+
+    private final SimulationService simulationService;
+
+    public SimulationController(SimulationService simulationService) {
+        this.simulationService = simulationService;
+    }
+
+    @GetMapping("/{simId}")
+    public ResponseEntity<?> getSimulation(@PathVariable String simId) {
+        if (simId.length() > 5 || simId.isBlank()) {
+            return ResponseEntity.badRequest().body("simulationID is invalid");
+        }
+
+        Optional<Simulation> simulation = simulationService.getSimulationBySimId(simId);
+
+        if (simulation == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(simulation);
+    }
+
+    @PostMapping("/createSimulation")
+    public ResponseEntity<String>create(@RequestBody Simulation sim) {
+        simulationService.saveSimulation(sim);
+        return new ResponseEntity<>("Simulation created successfully", HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/batterysimulator_db_operations/SimulationRepository.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/SimulationRepository.java
@@ -1,0 +1,7 @@
+package com.example.batterysimulator_db_operations;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SimulationRepository extends JpaRepository<Simulation, Long> {
+    //Additional custom queries or methods added here if needed
+}

--- a/src/main/java/com/example/batterysimulator_db_operations/SimulationResultRepository.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/SimulationResultRepository.java
@@ -1,0 +1,7 @@
+package com.example.batterysimulator_db_operations;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SimulationResultRepository extends JpaRepository<SimulationResults, Long> {
+    //Additional custom queries or methods added here if needed
+}

--- a/src/main/java/com/example/batterysimulator_db_operations/SimulationResults.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/SimulationResults.java
@@ -1,0 +1,26 @@
+package com.example.batterysimulator_db_operations;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimulationResults {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long simResultsId;
+
+    @ManyToOne
+    @JoinColumn(name = "simulation_simId")
+    private Simulation simulation;
+
+    private Double current;
+    private Double dcap;
+    private Double time;
+    private Double voltage;
+}

--- a/src/main/java/com/example/batterysimulator_db_operations/SimulationService.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/SimulationService.java
@@ -1,0 +1,24 @@
+package com.example.batterysimulator_db_operations;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class SimulationService {
+
+    private final SimulationRepository simulationRepo;
+
+    public SimulationService(SimulationRepository simulationRepo) {
+        this.simulationRepo = simulationRepo;
+    }
+
+    //Save a simulation
+    public void saveSimulation(Simulation sim) {
+        simulationRepo.save(sim);
+    }
+
+    public Optional<Simulation> getSimulationBySimId(String simId) {
+        return simulationRepo.findById(Long.valueOf(simId));
+    }
+}

--- a/src/main/java/com/example/batterysimulator_db_operations/SimulationType.java
+++ b/src/main/java/com/example/batterysimulator_db_operations/SimulationType.java
@@ -1,0 +1,9 @@
+package com.example.batterysimulator_db_operations;
+
+public enum SimulationType {
+    SINGLE_CELL,
+    BATTERY_PACK,
+    DRIVE_CYCLE,
+
+    //Add more simulation types as needed
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
-
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=guest
+spring.datasource.password=guest
+spring.h2.console.enabled=true


### PR DESCRIPTION
Added base files for database integration with JPA and H2. Simulation takes simulationType input (single cell, battery pack, drive cycle) and saves that as an entry to the Simulation table. It also takes the simulation results array and stores it into a separate table referenced by Simulation as a OneToMany relationship. i.e. Simulation stores multiple simulations of different types (single cell, pack etc.), and Simulation Results stores all the simulated values of that specific simulation.